### PR TITLE
Revert "Update the SwapRequestReceipt parameters to include the tokenIn and tokenOut instead of only a token parameter representing the tokenOut"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ flat/
 
 # Soldeer
 dependencies/
+
+# Audit 
+audit/audit-response.md

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,7 +3,7 @@ src = "src"
 out = "out"
 libs = ["lib", "dependencies"]
 optimizer = true
-optimizer_runs = 20000
+optimizer_runs = 200000
 solc_version = '0.8.30'
 gas_reports = ["*"]
 fs_permissions = [{ access = "read-write", path = "./script/" }]

--- a/src/Router.sol
+++ b/src/Router.sol
@@ -226,8 +226,7 @@ contract Router is ReentrancyGuard, IRouter, ScheduledUpgradeable, AccessControl
             requestId: requestId,
             srcChainId: srcChainId,
             dstChainId: getChainID(),
-            tokenIn: tokenIn,
-            tokenOut: tokenOut, // tokenOut is the token being received on the destination chain
+            token: tokenOut, // tokenOut is the token being received on the destination chain
             fulfilled: true, // indicates the transfer was fulfilled, prevents double fulfillment
             solver: msg.sender,
             recipient: recipient,
@@ -454,8 +453,7 @@ contract Router is ReentrancyGuard, IRouter, ScheduledUpgradeable, AccessControl
     /// @return requestId The unique ID of the swap request
     /// @return srcChainId The source chain ID from which the request originated
     /// @return dstChainId The destination chain ID where the tokens were delivered
-    /// @return tokenIn The token being sent on the source chain
-    /// @return tokenOut The token being received on the destination chain
+    /// @return token The address of the token involved in the transfer
     /// @return fulfilled Indicates if the transfer was fulfilled
     /// @return solver The address of the solver who fulfilled the transfer
     /// @return recipient The address that received the tokens on the destination chain
@@ -468,8 +466,7 @@ contract Router is ReentrancyGuard, IRouter, ScheduledUpgradeable, AccessControl
             bytes32 requestId,
             uint256 srcChainId,
             uint256 dstChainId,
-            address tokenIn,
-            address tokenOut,
+            address token,
             bool fulfilled,
             address solver,
             address recipient,
@@ -481,8 +478,7 @@ contract Router is ReentrancyGuard, IRouter, ScheduledUpgradeable, AccessControl
         requestId = receipt.requestId;
         srcChainId = receipt.srcChainId;
         dstChainId = receipt.dstChainId;
-        tokenIn = receipt.tokenIn;
-        tokenOut = receipt.tokenOut;
+        token = receipt.token;
         fulfilled = receipt.fulfilled;
         solver = receipt.solver;
         recipient = receipt.recipient;

--- a/src/interfaces/IRouter.sol
+++ b/src/interfaces/IRouter.sol
@@ -36,8 +36,7 @@ interface IRouter {
         bytes32 requestId; // Reference to the original request on the source chain
         uint256 srcChainId; // Source chain ID from which the request originated
         uint256 dstChainId; // Destination chain ID where the request was fulfilled
-        address tokenIn; // Token being sent on the source chain
-        address tokenOut; // Token being received on the destination chain
+        address token; // Token being transferred
         bool fulfilled; // Whether the transfer has been delivered
         address solver; // Address that fulfilled the request
         address recipient; // Recipient of the tokens on the destination chain
@@ -231,8 +230,7 @@ interface IRouter {
     /// @return requestId The unique ID of the swap request
     /// @return srcChainId The source chain ID from which the request originated
     /// @return dstChainId The destination chain ID where the tokens were delivered
-    /// @return tokenIn The token being sent on the source chain
-    /// @return tokenOut The token being received on the destination chain
+    /// @return token The address of the token involved in the transfer
     /// @return fulfilled Indicates if the transfer was fulfilled
     /// @return solver The address of the solver who fulfilled the transfer
     /// @return recipient The address that received the tokens on the destination chain
@@ -245,8 +243,7 @@ interface IRouter {
             bytes32 requestId,
             uint256 srcChainId,
             uint256 dstChainId,
-            address tokenIn,
-            address tokenOut,
+            address token,
             bool fulfilled,
             address solver,
             address recipient,

--- a/src/mocks/MockRouterV2.sol
+++ b/src/mocks/MockRouterV2.sol
@@ -224,8 +224,7 @@ contract MockRouterV2 is ReentrancyGuard, IRouter, ScheduledUpgradeable, AccessC
             requestId: requestId,
             srcChainId: srcChainId,
             dstChainId: getChainID(),
-            tokenIn: tokenIn,
-            tokenOut: tokenOut, // tokenOut is the token being received on the destination chain
+            token: tokenOut, // tokenOut is the token being received on the destination chain
             fulfilled: true, // indicates the transfer was fulfilled, prevents double fulfillment
             solver: msg.sender,
             recipient: recipient,
@@ -447,8 +446,7 @@ contract MockRouterV2 is ReentrancyGuard, IRouter, ScheduledUpgradeable, AccessC
     /// @return requestId The unique ID of the swap request
     /// @return srcChainId The source chain ID from which the request originated
     /// @return dstChainId The destination chain ID where the tokens were delivered
-    /// @return tokenIn The token being sent on the source chain
-    /// @return tokenOut The token being received on the destination chain
+    /// @return token The address of the token involved in the transfer
     /// @return fulfilled Indicates if the transfer was fulfilled
     /// @return solver The address of the solver who fulfilled the transfer
     /// @return recipient The address that received the tokens on the destination chain
@@ -461,8 +459,7 @@ contract MockRouterV2 is ReentrancyGuard, IRouter, ScheduledUpgradeable, AccessC
             bytes32 requestId,
             uint256 srcChainId,
             uint256 dstChainId,
-            address tokenIn,
-            address tokenOut,
+            address token,
             bool fulfilled,
             address solver,
             address recipient,
@@ -474,8 +471,7 @@ contract MockRouterV2 is ReentrancyGuard, IRouter, ScheduledUpgradeable, AccessC
         requestId = receipt.requestId;
         srcChainId = receipt.srcChainId;
         dstChainId = receipt.dstChainId;
-        tokenIn = receipt.tokenIn;
-        tokenOut = receipt.tokenOut;
+        token = receipt.token;
         fulfilled = receipt.fulfilled;
         solver = receipt.solver;
         recipient = receipt.recipient;

--- a/test/hardhat/Router.test.ts
+++ b/test/hardhat/Router.test.ts
@@ -570,12 +570,10 @@ describe("Router", function () {
     expect(await dstToken.balanceOf(recipientAddr)).to.equal(amount);
 
     // Check receipt
-    const swapRequestReceipt = await router.getSwapRequestReceipt(requestId);
-    const [, , , , , fulfilled, solver, , amountOut] = swapRequestReceipt;
-
-    expect(fulfilled).to.be.true;
-    expect(amountOut).to.equal(amount);
-    expect(solver).to.equal(userAddr);
+    const receipt = await router.swapRequestReceipts(requestId);
+    expect(receipt.fulfilled).to.be.true;
+    expect(receipt.amountOut).to.equal(amount);
+    expect(receipt.solver).to.equal(userAddr);
 
     expect((await router.getFulfilledTransfers()).includes(requestId)).to.be.equal(true);
     expect((await router.getFulfilledTransfers()).length).to.be.equal(1);
@@ -605,13 +603,13 @@ describe("Router", function () {
     const nonce = 1;
 
     // Check recipient balance before transfer
-    expect(await dstToken.balanceOf(recipientAddr)).to.equal(0);
+    expect(await srcToken.balanceOf(recipientAddr)).to.equal(0);
 
     // Mint tokens for user
-    await dstToken.mint(userAddr, amount);
+    await srcToken.mint(userAddr, amount);
 
     // Approve Router to spend user's tokens
-    await dstToken.connect(user).approve(await router.getAddress(), amount);
+    await srcToken.connect(user).approve(await router.getAddress(), amount);
 
     // Pre-compute valid requestId
     const abiCoder = new AbiCoder();
@@ -650,7 +648,7 @@ describe("Router", function () {
       .withArgs(srcChainId, dstChainId);
 
     // Check recipient balance after transfer
-    expect(await dstToken.balanceOf(recipientAddr)).to.equal(0);
+    expect(await srcToken.balanceOf(recipientAddr)).to.equal(0);
   });
 
   it("should revert if requestId reconstruction fails", async () => {
@@ -660,13 +658,13 @@ describe("Router", function () {
     const nonce = 1;
 
     // Check recipient balance before transfer
-    expect(await dstToken.balanceOf(recipientAddr)).to.equal(0);
+    expect(await srcToken.balanceOf(recipientAddr)).to.equal(0);
 
     // Mint tokens for user
-    await dstToken.mint(userAddr, amount);
+    await srcToken.mint(userAddr, amount);
 
     // Approve Router to spend user's tokens
-    await dstToken.connect(user).approve(await router.getAddress(), amount);
+    await srcToken.connect(user).approve(await router.getAddress(), amount);
 
     // Pre-compute valid requestId
     const abiCoder = new AbiCoder();
@@ -703,7 +701,7 @@ describe("Router", function () {
     ).to.be.revertedWithCustomError(router, "SwapRequestParametersMismatch()");
 
     // Check recipient balance after transfer
-    expect(await dstToken.balanceOf(recipientAddr)).to.equal(0);
+    expect(await srcToken.balanceOf(recipientAddr)).to.equal(0);
   });
 
   it("should return correct verification fee amount for a given swap amount", async () => {
@@ -873,18 +871,15 @@ describe("Router", function () {
     expect((await router.getFulfilledTransfers()).length).to.be.equal(1);
 
     const swapRequestReceipt = await router.getSwapRequestReceipt(requestId);
-    const [, , , srcTokenAddr, dstTokenAddr, fulfilled, sender, recipient, amountOut] = swapRequestReceipt;
-
     // Check receipt values
-    expect(reqId).to.equal(requestId);
-    expect(sourceChainId).to.equal(srcChainId);
-    expect(dstChainId).to.equal(await router.getChainID());
-    expect(srcTokenAddr).to.equal(await srcToken.getAddress());
-    expect(dstTokenAddr).to.equal(await dstToken.getAddress());
-    expect(fulfilled).to.be.true;
-    expect(sender).to.equal(userAddr);
-    expect(recipient).to.equal(recipientAddr);
-    expect(amountOut).to.equal(amount);
+    expect(swapRequestReceipt[0]).to.equal(requestId);
+    expect(swapRequestReceipt[1]).to.equal(srcChainId);
+    expect(swapRequestReceipt[2]).to.equal(await router.getChainID());
+    expect(swapRequestReceipt[3]).to.equal(await dstToken.getAddress());
+    expect(swapRequestReceipt[4]).to.be.true;
+    expect(swapRequestReceipt[5]).to.equal(userAddr);
+    expect(swapRequestReceipt[6]).to.equal(recipientAddr);
+    expect(swapRequestReceipt[7]).to.equal(amount);
 
     // Check transaction receipt values compared to emitted event
     expect(reqId).to.equal(swapRequestReceipt[0]);
@@ -1118,13 +1113,13 @@ describe("Router", function () {
     const nonce = 1;
 
     // Check recipient balance before transfer
-    expect(await dstToken.balanceOf(recipientAddr)).to.equal(0);
+    expect(await srcToken.balanceOf(recipientAddr)).to.equal(0);
 
     // Mint tokens for user
-    await dstToken.mint(userAddr, amount);
+    await srcToken.mint(userAddr, amount);
 
     // Approve Router to spend user's tokens
-    await dstToken.connect(user).approve(await router.getAddress(), amount);
+    await srcToken.connect(user).approve(await router.getAddress(), amount);
 
     // Pre-compute valid requestId
     const abiCoder = new AbiCoder();
@@ -1168,13 +1163,13 @@ describe("Router", function () {
     recipientAddr = ZeroAddress;
 
     // Check recipient balance before transfer
-    expect(await dstToken.balanceOf(recipientAddr)).to.equal(0);
+    expect(await srcToken.balanceOf(recipientAddr)).to.equal(0);
 
     // Mint tokens for user
-    await dstToken.mint(userAddr, amount);
+    await srcToken.mint(userAddr, amount);
 
     // Approve Router to spend user's tokens
-    await dstToken.connect(user).approve(await router.getAddress(), amount);
+    await srcToken.connect(user).approve(await router.getAddress(), amount);
 
     // Pre-compute valid requestId
     const abiCoder = new AbiCoder();


### PR DESCRIPTION
Reverts randa-mu/onlyswaps-solidity#74